### PR TITLE
Clarify location of Health Data

### DIFF
--- a/index.md
+++ b/index.md
@@ -174,3 +174,5 @@ device using its mDNS hostname, which is just the hostname with `.local`, e.g. `
 ### Via WeatherLink.com
 If you are the registered owner of the device on [WeatherLink.com](https://www.weatherlink.com), you can find the
 device's IP address on the "Health Data" page, listed as "AirLink IP Address".
+
+This may be found from the right "Wrench" tool icon, select registered AirLink device name, expand device name, and select "Health Data" from the top portion of the page.


### PR DESCRIPTION
Provide more data on where the health data link is located.

Suggestion, maybe provide a URL on the AirLink resident HTTP web page that links to `https://www.weatherlink.com/manageDevices/node/<<MAC Address>>`.